### PR TITLE
144 error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ng": "ng",
     "start": "concurrently  \"npm run watch:sass\" \"npm run build\" \"ng serve\"",
     "build": "ng build",
-    "ngexp": "ng build && node server.js",
+    "build-run": "ng build && node server.js",
     "test": "ng test",
     "test-coverage": "ng test --code-coverage --reporters=coverage-istanbul",
     "lint": "ng lint",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ng": "ng",
     "start": "concurrently  \"npm run watch:sass\" \"npm run build\" \"ng serve\"",
     "build": "ng build",
-    "build-run": "ng build && node server.js",
+    "ngexp": "ng build && node server.js",
     "test": "ng test",
     "test-coverage": "ng test --code-coverage --reporters=coverage-istanbul",
     "lint": "ng lint",

--- a/server.js
+++ b/server.js
@@ -22,8 +22,8 @@ const app = express()
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: false }))
 
-app.use(function (req, res, next) {
-  var user = auth(req)
+app.use((req, res, next) => {
+  const user = auth(req)
   if (user === undefined || user.name !== configData.basicAuth.name || user.pass !== configData.basicAuth.pass) {
     res.send('unauthorised access attempt')
     return
@@ -86,20 +86,18 @@ pem.createCertificate({ days: 1, selfSigned: true }, (error, keys) => {
     /**
     * Connect to mongoose
     */
-    
+
     mongoose.Promise = global.Promise
-    
+
     const mongoDB = 'mongodb://127.0.0.1/polymorph'
     mongoose.connect(mongoDB)
     const db = mongoose.connection
     db.on('error', console.error.bind(console, 'MongoDB connection error:'))
-    
+
     Logger.writeLog('MongoDB Connect', `Conected to MongoDB on ${mongoDB}`, null, false)
 
     Logger.writeLog('n/a', 'Sending start up notification email.', null, false)
     Logger.writeLog('Server Start Up', 'Start Up Complete @' + new Date().toISOString() +
       ', Polymorph Version: ' + config.version, null, true)
-
   })
 })
-

--- a/server/lib/order/order.ctrl.js
+++ b/server/lib/order/order.ctrl.js
@@ -112,7 +112,7 @@ OrderCtrl.checkForMaintenance = () => {
   return new Promise((fulfill, reject) => {
     serverModeCtrl.checkMode()
     .then((mode) => {
-      if(mode === 'MAINTENANCE'){
+      if(mode[0].server_mode === 'MAINTENANCE'){
         fulfill(true)
       } else {
         fulfill(false)

--- a/server/lib/order/order.ctrl.js
+++ b/server/lib/order/order.ctrl.js
@@ -156,9 +156,6 @@ OrderCtrl.getChangellyAddress = (inputCurrency, outputCurrency, destAddress) => 
       extraId: null,
     })
     .then((data) => {
-      if (data instanceof Error) {
-        reject(data)
-      }
       fulfill(data.result.address)
     })
     .catch((error) => { reject(error) })

--- a/server/lib/order/order.ctrl.js
+++ b/server/lib/order/order.ctrl.js
@@ -54,7 +54,6 @@ OrderCtrl.getFirstChangellyAddress = (req, res) => {
   } else {
     OrderCtrl.getChangellyAddress(req.params.from, 'NAV', req.params.navAddress)
     .then((address) => {
-
       req.params.changellyAddressOne = address
       OrderCtrl.getSecondChangellyAddress(req, res)
     })
@@ -122,7 +121,6 @@ OrderCtrl.checkForMaintenance = () => {
   })
 }
 
-
 OrderCtrl.validateParams = (req) => {
   return new Promise((fulfill, reject) => {
     // TODO: Add validation for extraId
@@ -163,6 +161,7 @@ OrderCtrl.getChangellyAddress = (inputCurrency, outputCurrency, destAddress) => 
       }
       fulfill(data.result.address)
     })
+    .catch((error) => { reject(error) })
   })
 }
 

--- a/server/lib/socket/socketCtrl.js
+++ b/server/lib/socket/socketCtrl.js
@@ -33,7 +33,7 @@ const socketCtrl = {}
     setInterval(() => {
       serverModeCtrl.checkMode()
       .then((mode) => {
-        if(mode.length === 1 && previousMode !== mode) {
+        if (mode.length === 1 && previousMode !== mode) {
           previousMode = mode
           socket.emit('SERVER_MODE', mode[0].server_mode)
         }
@@ -42,8 +42,8 @@ const socketCtrl = {}
         return serverModeCtrl.checkMessage()
       })
       .then((serverMessageData) => {
-        if(serverMessageData.length === 1 && previousMessage !== serverMessageData) {
-          previousMode = mode
+        if (serverMessageData.length === 1 && previousMessage !== serverMessageData) {
+          previousMode = serverMessageData
           socket.emit('SERVER_MESSAGE', {
             serverMessage: serverMessageData[0].server_message,
             serverMessageType: serverMessageData[0].message_type,

--- a/src/app/components/send-coins-form/send-coins-form.component.html
+++ b/src/app/components/send-coins-form/send-coins-form.component.html
@@ -7,6 +7,7 @@
       <li *ngIf="errors.indexOf('NOT_FOUND') > -1">Unable to load available currencies from Changelly</li>
       <li *ngIf="errors.indexOf('DATA_FORMAT') > -1">Recevied incorrectly formatted data from Changelly</li>
       <li *ngIf="errors.indexOf('ORDER_CREATION_FAILED') > -1">Failed to create a Polymorph order</li>
+      <li *ngIf="errors.indexOf('MAINTENANCE_MODE') > -1">Maintenance Mode is currently active, creation of new orders is disabled</li>
       <li *ngIf="errors.indexOf('EXPIRED_EST') > -1">Your estimate has expired, click send to fetch a new one</li>
       <li *ngIf="errors.indexOf('DEFAULT') > -1">Error displaying available currencies</li>
     </ul>

--- a/src/app/components/send-coins-form/send-coins-form.component.ts
+++ b/src/app/components/send-coins-form/send-coins-form.component.ts
@@ -147,8 +147,10 @@ export class SendCoinsFormComponent implements OnInit, OnDestroy {
         if (result.type === "FAIL" ){
           this.errors.push('ORDER_CREATION_FAILED')
           return
+        } else if (result.type === "MAINTENANCE" ){
+          this.errors.push('MAINTENANCE_MODE')
+          return
         }
-
         const statusPageUrl = '/status/' + result.data['0'] + '/' + result.data['1']
         this.router.navigateByUrl(statusPageUrl)
       },

--- a/src/app/components/status/status.component.html
+++ b/src/app/components/status/status.component.html
@@ -13,7 +13,9 @@
       <div class="error-text" *ngIf="formData.errors.indexOf('TRANSFER_TOO_SMALL') > -1">You're attempting to send too few coins. Changelly requires at least {{formData.minTransferAmount | number:'1.0-8' }} {{formData.originCoin | uppercase}} </div>
       <div class="error-text" *ngIf="formData.errors.indexOf('TRANSFER_TOO_LARGE') > -1">You're attempting to send too many coins at once, our current limit is {{MAX_NAV_PER_TRADE | number:'1.0-8'  }} NAV per trade. You're attempting to send {{formData.estConvToNav | number:'1.0-8'  }} NAV.</div>
       <div class="error-text" *ngIf="formData.errors.indexOf('NAV_TO_NAV_TRANSFER') > -1">You're attempting a NAV to NAV anonymous transfer, please use NavTech wallet's built in anon transaction feature for this.</div>
-      <div class="error-text" *ngIf="formData.errors.indexOf('CHANGELLY_ERROR') > -1">There was an error contacting Changelly servers, please try again.</div>
+      <!-- <div class="error-text" *ngIf="formData.errors.indexOf('CHANGELLY_ERROR') > -1">There was an error contacting Changelly servers, please try again.</div> -->
+      <div class="error-text" *ngIf="formData.errors.indexOf('ETA_ERROR') > -1">There was an error fetching an ETA.</div>
+
     </div>
     <div *ngIf="formData.errors.length <= 0">
       <div>

--- a/src/app/services/changelly-api/changelly-api.ts
+++ b/src/app/services/changelly-api/changelly-api.ts
@@ -10,20 +10,20 @@ export class ChangellyApiService {
   constructor( private genServ:GenericNodeApiService) { }
 
   getCurrencies() {
-    return this.getApiRequest( changellyNodeApiEndPoints.getCurrencies, undefined)
+    return this.getApiRequest(changellyNodeApiEndPoints.getCurrencies, undefined)
   }
 
 
   getEta(originCoin, destCoin) {
-    return this.getApiRequest( changellyNodeApiEndPoints.getEta, [originCoin, destCoin])
+    return this.getApiRequest(changellyNodeApiEndPoints.getEta, [originCoin, destCoin])
   }
 
   getMinAmount(originCoin, destCoin) {
-    return this.getApiRequest( changellyNodeApiEndPoints.getMinAmount, [originCoin, destCoin])
+    return this.getApiRequest(changellyNodeApiEndPoints.getMinAmount, [originCoin, destCoin])
   }
 
   getExchangeAmount(originCoin, destCoin, amount) {
-    return this.getApiRequest( changellyNodeApiEndPoints.getExchangeAmount, [originCoin, destCoin, amount])
+    return this.getApiRequest(changellyNodeApiEndPoints.getExchangeAmount, [originCoin, destCoin, amount])
   }
 
   getApiRequest(endpoint, params){


### PR DESCRIPTION
### Changes:
* Proper handling of maintenance mode.
* Updated error handling for when we fail to generate a changelly address
* Renamed an npm command to make it easier to build and launch the server. `npm run ngexp` ( runs `ng build && npm run express`)
* Added error handling in case we fail to generate an ETA
* Added error handling in case the front end fails to talk to changelly at various points (getting estimates)

- - -
[Elegantt data. What's this?](http://bit.ly/elegantt-for-trello-whats-this)
[](Elegantt!UNITO-UNDERSCORE!data:dont!UNITO-UNDERSCORE!delete{"ignored":false,"autoPlanned":false,"ownerId":false,"dependencies":[]})

